### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Use your plugin manager of choice.
 - [Pathogen](https://github.com/tpope/vim-pathogen)
   - `git clone https://github.com/JarrodCTaylor/vim-shell-executor ~/.vim/bundle/vim-shell-executor`
 - [Vundle](https://github.com/gmarik/vundle)
-  - Add `Bundle 'https://github.com/JarrodCTaylor/vim-shell-executor'` to .vimrc
-  - Run `:BundleInstall`
+  - Add `Plugin 'https://github.com/JarrodCTaylor/vim-shell-executor'` to .vimrc
+  - Run `:PluginInstall`
 - [NeoBundle](https://github.com/Shougo/neobundle.vim)
   - Add `NeoBundle 'https://github.com/JarrodCTaylor/vim-shell-executor'` to .vimrc
   - Run `:NeoBundleInstall`


### PR DESCRIPTION
Replace deprecated names for Vundle.

Relevant section of the Vundle docs: https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L397