### PR TITLE
Allow use of multiple vim instances to be used at once

### DIFF
--- a/autoload/vim_shell_executor.py
+++ b/autoload/vim_shell_executor.py
@@ -1,21 +1,23 @@
 import subprocess
+import random
 import os
 
-INPUT_FILE = "/tmp/input"
-ERROR_LOG = "/tmp/error.log"
-RESULTS_FILE = "/tmp/results"
 
 def get_command_from_first_line(line):
     if line.startswith("#!"):
         return line[2:]
     return line
 
+
 def get_program_output_from_buffer_contents(buffer_contents):
-    write_buffer_contents_to_file(INPUT_FILE, buffer_contents[1:])
+    input_file = '/tmp/vim-exec-buffer-{}.log'.format(random.randint(0, 999))
+    error_file = '/tmp/vim-exec-buffer-error-{}.log'.format(random.randint(0, 999))
+    results_file = '/tmp/vim-exec-buffer-results-{}.log'.format(random.randint(0, 999))
+    write_buffer_contents_to_file(input_file, buffer_contents[1:])
     command = get_command_from_first_line(buffer_contents[0])
-    execute_file_with_specified_shell_program(command)
-    errors = read_file_lines(ERROR_LOG)
-    std_out = read_file_lines(RESULTS_FILE)
+    execute_file_with_specified_shell_program(command, input_file, error_file, results_file)
+    errors = read_file_lines(error_file)
+    std_out = read_file_lines(results_file)
     new_buf = errors + std_out
     return new_buf
 
@@ -26,14 +28,14 @@ def write_buffer_contents_to_file(file_name, contents):
             f.write(line + "\n")
 
 
-def execute_file_with_specified_shell_program(shell_command):
+def execute_file_with_specified_shell_program(shell_command, input_file, error_file, results_file):
     try:
         subprocess.check_call("{0} {1} {2} > {3} 2> {4}".format(
             shell_command,
             redirect_or_arg(shell_command),
-            INPUT_FILE,
-            RESULTS_FILE,
-            ERROR_LOG),
+            input_file,
+            results_file,
+            error_file),
             shell=True
         )
     except:

--- a/autoload/vim_shell_executor.vim
+++ b/autoload/vim_shell_executor.vim
@@ -38,6 +38,7 @@ let startExecutionTime = strftime("%T")
 echo "Execution started at: " . startExecutionTime
 Py << endPython
 from vim_shell_executor import *
+from random import randint
 
 def create_new_buffer(contents):
     vim.command('normal! Hmx``')

--- a/tests/vim_shell_executor_tests.py
+++ b/tests/vim_shell_executor_tests.py
@@ -15,6 +15,12 @@ class VimShellExecutorTests(unittest.TestCase):
         self.delete_if_present(INPUT_FILE)
         self.delete_if_present(RESULTS_FILE)
 
+    def test_using_plugin_in_two_different_vim_sessions_at_the_same_time_does_not_override_each_others_output(self):
+        buffer_contents = ["python", "print('Hi One')"]
+        return_result = sut.get_program_output_from_buffer_contents(buffer_contents)
+        expected_result = ["Hi One"]
+        self.assertEqual(expected_result, return_result)
+
     def test_get_program_output_from_buffer_contents_returns_properly_formatted_results_when_given_valid_python_input(self):
         buffer_contents = ["python", "name = 'Jarrod'", "", "def hello():", "    print('Hello {0}'.format(name))", "", "hello()"]
         return_result = sut.get_program_output_from_buffer_contents(buffer_contents)
@@ -23,9 +29,9 @@ class VimShellExecutorTests(unittest.TestCase):
 
     def test_get_program_output_from_buffer_contents_returns_expected_error_when_given_invalid_input(self):
         buffer_contents = ["not_a_program", "fail = 27"]
-        expected_error = ['/bin/sh: 1: not_a_program: not found']
+        expected_error = (['/bin/sh: 1: not_a_program: not found'], ['/bin/sh: not_a_program: command not found'])
         returned_buffer = sut.get_program_output_from_buffer_contents(buffer_contents)
-        self.assertEqual(expected_error, returned_buffer)
+        self.assertIn(returned_buffer, expected_error)
 
     def test_get_program_output_from_buffer_contents_returns_expected_content_when_error_and_std_out_are_produced(self):
         buffer_contents = ["python", "print('This is good')", "raise Exception('This is bad')"]
@@ -41,7 +47,7 @@ class VimShellExecutorTests(unittest.TestCase):
 
     def test_execute_file_with_specific_shell_program_populates_an_error_file_when_given_invalid_input_for_specified_shell_command(self):
         sut.write_buffer_contents_to_file(INPUT_FILE, ["(def name 'Jarrod')", "(println name)"])
-        sut.execute_file_with_specified_shell_program('python')
+        sut.execute_file_with_specified_shell_program('python', INPUT_FILE, ERROR_LOG, RESULTS_FILE)
         self.assertTrue(os.stat(ERROR_LOG)[stat.ST_SIZE] > 0)
 
     def read_file_to_string(self, file_to_read):


### PR DESCRIPTION
I'm not sure the best way to write a test to demonstrate this... I started one... then.... that was as far as I got....

It's pretty easy to replicate - say you've got a python script in one terminal and a query in another... you kick off the python script using this plugin, then while it's running kick off the query - which gets an error - then the python script ends and you end up with the Python scripts output and the query's errors in the output pane of the python script.... I believe this should fix that issue... 